### PR TITLE
Tests SaveTicker Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cmd/__debug_bin
 config_*.yml
 *.orig
 *~
+mocks
 
 ### macOS ###
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,16 @@ exec:
 ## clean: Clean build files. Runs `go clean` internally.
 clean:
 	@-rm $(GOBIN)/$(PROJECT_NAME) 2> /dev/null
+	@-rm -rf mocks
 	@-$(MAKE) go-clean
 
+## generate-mocks: Creates mockfiles.
+generate-mocks:
+	@-mockery -dir storage -name DB
+	@-mockery -dir storage -name ProviderList
+
 ## test: Run all unit tests.
-test: go-test
+test: generate-mocks go-test
 
 ## functional: Run all functional tests.
 functional: go-functional

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.6.2
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.5
 	github.com/trustwallet/blockatlas v1.0.37
+	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 // indirect
 )

--- a/storage/market.go
+++ b/storage/market.go
@@ -54,6 +54,11 @@ func (s *Storage) GetTicker(coin, token string) (*watchmarket.Ticker, error) {
 func (s *Storage) SaveRates(rates watchmarket.Rates, pl ProviderList) {
 	for _, rate := range rates {
 		r, err := s.GetRate(rate.Currency)
+		if err != nil && err != watchmarket.ErrNotFound {
+			logger.Error(err, "SaveRates")
+			// TODO handle this properly
+			continue
+		}
 		if err == nil {
 			op := pl.GetPriority(r.Provider)
 			np := pl.GetPriority(rate.Provider)
@@ -61,7 +66,7 @@ func (s *Storage) SaveRates(rates watchmarket.Rates, pl ProviderList) {
 				continue
 			}
 
-			if rate.Timestamp < r.Timestamp && op >= np {
+			if rate.Timestamp < r.Timestamp && np <= op {
 				continue
 			}
 		}

--- a/storage/market_test.go
+++ b/storage/market_test.go
@@ -137,3 +137,189 @@ func TestSaveTickerWhenTickerExistsAndOutdated(t *testing.T) {
 
 	assert.Contains(t, err.Error(), "outdated")
 }
+
+func TestGetTickerNominal(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "myTestTokenId")
+
+	assert.Nil(t, err)
+}
+
+func TestGetTickerWithoutToken(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN", mock.AnythingOfType("**watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "")
+
+	assert.Nil(t, err)
+}
+
+func TestGetTickerError(t *testing.T) {
+	dbErr := errors.New("boom")
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(dbErr)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "myTestTokenId")
+
+	assert.Equal(t, dbErr, err)
+}
+
+func TestGetRateNominal(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetRate("myTestCurrency")
+
+	assert.Nil(t, err)
+}
+
+func TestGetRateError(t *testing.T) {
+	dbErr := errors.New("boom")
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(dbErr)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetRate("myTestCurrency")
+
+	assert.Equal(t, dbErr, err)
+}
+
+func TestSaveRatesNoExistingRate(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}
+
+func TestSaveRatesExistingRate(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        0,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        10,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(10)
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}
+
+func TestSaveRatesExistingRateNewRateLowPriority(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        0,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        10,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(10)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}
+
+func TestSaveRatesExistingRateNewRateOutdated(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        10,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        0,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}
+
+func TestSaveRatesDbSaveFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(watchmarket.ErrNotFound)
+	dbSaveFailure := errors.New("boom")
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(dbSaveFailure)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}
+func TestSaveRatesDbRetrievalFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	dbRetrievalFailure := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(dbRetrievalFailure)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	subject.SaveRates(mockRates, mockProviderList)
+
+	//  TBD Assertions
+}

--- a/storage/market_test.go
+++ b/storage/market_test.go
@@ -1,0 +1,139 @@
+package storage
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/trustwallet/watchmarket/mocks"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+	"testing"
+	"time"
+)
+
+func TestSaveTickerWhenTickerDoesntExist(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("*watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Nil(t, err)
+}
+
+func TestSaveTickerWhenTickerDoesntExistAndDbFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	addHMErr := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("*watchmarket.Ticker")).Return(addHMErr)
+
+	subject := &Storage{mockDb}
+
+	err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Equal(t, addHMErr, err)
+}
+
+func TestSaveTickerWhenTickerRetrievalFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	retrievalErr := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(retrievalErr)
+
+	subject := &Storage{mockDb}
+
+	err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Equal(t, retrievalErr, err)
+}
+
+func TestSaveTickerWhenTickerExistsAndPriorityTooLow(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(10)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+	mockTicker := &watchmarket.Ticker{
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		Price:      watchmarket.TickerPrice{
+			Provider:  "myNewTestProvider",
+		},
+		LastUpdate: time.Now(),
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Ticker) = &watchmarket.Ticker{
+			CoinName:   "myTestCoin",
+			TokenId:    "myTestTokenId",
+			Price:      watchmarket.TickerPrice{
+				Provider:  "myOldTestProvider",
+			},
+			LastUpdate: time.Now(),
+		}
+		return true
+	})).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Contains(t, err.Error(), "less priority")
+}
+
+func TestSaveTickerWhenTickerExistsAndOutdated(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(10)
+	mockTicker := &watchmarket.Ticker{
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		Price:      watchmarket.TickerPrice{
+			Provider:  "myNewTestProvider",
+		},
+		LastUpdate: time.Now(),
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Ticker) = &watchmarket.Ticker{
+			CoinName:   "myTestCoin",
+			TokenId:    "myTestTokenId",
+			Price:      watchmarket.TickerPrice{
+				Provider:  "myOldTestProvider",
+			},
+			LastUpdate: time.Now(),
+		}
+		return true
+	})).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Contains(t, err.Error(), "outdated")
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,16 +2,21 @@ package storage
 
 import (
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
-	"github.com/trustwallet/watchmarket/redis"
 )
 
 type Storage struct {
-	redis.Redis
+	DB
 }
 
 func New() *Storage {
 	s := new(Storage)
 	return s
+}
+
+type DB interface {
+	GetHMValue(entity, key string, value interface{}) error
+	AddHM(entity, key string, value interface{}) error
+	Init(host string) error
 }
 
 type Market interface {


### PR DESCRIPTION
_DRAFT_

Integrates `testify/mock` to mock out _Redis_ (and other dependencies going forward).

As an example this tests the SaveTicker logic. 

_github.com/trustwallet/watchmarket/storage_ Coverage before: 0%
_github.com/trustwallet/watchmarket/storage_ Coverage after: 52.6%
```